### PR TITLE
Set default UVU colors and updated visuals

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -15,14 +15,14 @@ files = [
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
-    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
 
 [[package]]
@@ -55,14 +55,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
-    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [package.dependencies]
@@ -76,30 +76,30 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments
 
 [[package]]
 name = "ruff"
-version = "0.9.7"
+version = "0.9.10"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.9.7-py3-none-linux_armv6l.whl", hash = "sha256:99d50def47305fe6f233eb8dabfd60047578ca87c9dcb235c9723ab1175180f4"},
-    {file = "ruff-0.9.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d59105ae9c44152c3d40a9c40d6331a7acd1cdf5ef404fbe31178a77b174ea66"},
-    {file = "ruff-0.9.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f313b5800483770bd540cddac7c90fc46f895f427b7820f18fe1822697f1fec9"},
-    {file = "ruff-0.9.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:042ae32b41343888f59c0a4148f103208bf6b21c90118d51dc93a68366f4e903"},
-    {file = "ruff-0.9.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87862589373b33cc484b10831004e5e5ec47dc10d2b41ba770e837d4f429d721"},
-    {file = "ruff-0.9.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a17e1e01bee0926d351a1ee9bc15c445beae888f90069a6192a07a84af544b6b"},
-    {file = "ruff-0.9.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7c1f880ac5b2cbebd58b8ebde57069a374865c73f3bf41f05fe7a179c1c8ef22"},
-    {file = "ruff-0.9.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e63fc20143c291cab2841dbb8260e96bafbe1ba13fd3d60d28be2c71e312da49"},
-    {file = "ruff-0.9.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:91ff963baed3e9a6a4eba2a02f4ca8eaa6eba1cc0521aec0987da8d62f53cbef"},
-    {file = "ruff-0.9.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88362e3227c82f63eaebf0b2eff5b88990280fb1ecf7105523883ba8c3aaf6fb"},
-    {file = "ruff-0.9.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0372c5a90349f00212270421fe91874b866fd3626eb3b397ede06cd385f6f7e0"},
-    {file = "ruff-0.9.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d76b8ab60e99e6424cd9d3d923274a1324aefce04f8ea537136b8398bbae0a62"},
-    {file = "ruff-0.9.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0c439bdfc8983e1336577f00e09a4e7a78944fe01e4ea7fe616d00c3ec69a3d0"},
-    {file = "ruff-0.9.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:115d1f15e8fdd445a7b4dc9a30abae22de3f6bcabeb503964904471691ef7606"},
-    {file = "ruff-0.9.7-py3-none-win32.whl", hash = "sha256:e9ece95b7de5923cbf38893f066ed2872be2f2f477ba94f826c8defdd6ec6b7d"},
-    {file = "ruff-0.9.7-py3-none-win_amd64.whl", hash = "sha256:3770fe52b9d691a15f0b87ada29c45324b2ace8f01200fb0c14845e499eb0c2c"},
-    {file = "ruff-0.9.7-py3-none-win_arm64.whl", hash = "sha256:b075a700b2533feb7a01130ff656a4ec0d5f340bb540ad98759b8401c32c2037"},
-    {file = "ruff-0.9.7.tar.gz", hash = "sha256:643757633417907510157b206e490c3aa11cab0c087c912f60e07fbafa87a4c6"},
+    {file = "ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d"},
+    {file = "ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d"},
+    {file = "ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8"},
+    {file = "ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029"},
+    {file = "ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1"},
+    {file = "ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69"},
+    {file = "ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7"},
 ]
 
 [[package]]

--- a/src/cpu.py
+++ b/src/cpu.py
@@ -291,7 +291,7 @@ class CPU:
         gui.io_text.config(state=tk.NORMAL)
         gui.io_text.delete("0", "end")
         gui.io_text.bind("<Return>", read_input)
-        gui.io_label.configure(text="Read a 4-digit signed instruction: ")
+        gui.io_label.configure(text="Read a 4-digit signed instruction: (Press enter to submit)")
         gui.input = tk.StringVar()
         gui.root.wait_variable(gui.input)
         gui.io_text.delete("0", "end")

--- a/src/gui.py
+++ b/src/gui.py
@@ -543,7 +543,7 @@ class App:
         self.status_label.config(text="Status: Ready")
         self.update_memory_text()
         # Switch focus to memory frame after loading
-        self.highlight_memory_frame()
+        self.highlight_main_frame()
 
     def adjust_memory_font_size(self, event=None):
         '''Dynamically adjusts font size to fit text within memory_text widget with some padding.'''
@@ -634,7 +634,7 @@ class App:
 
         self.status_label.config(text="Status: Running")
         # Switch focus to control frame when running
-        self.highlight_memory_frame()
+        self.highlight_main_frame()
             
         try:
             self.boot.run(self, cont)
@@ -828,14 +828,16 @@ class App:
     def highlight_program_frame(self):
         '''Highlight the program frame and darken other frames'''
         self.program_frame.configure(style='Primary.TFrame')
+        self.instruction_frame.configure(style='Darkened.TFrame')
         self.memory_frame.configure(style='Darkened.TFrame')
         self.control_frame.configure(style='Darkened.TFrame')
 
         self.update_memory_text()
 
-    def highlight_memory_frame(self):
+    def highlight_main_frame(self):
         '''Highlight the memory frame and darken other frames'''
         self.program_frame.configure(style='Darkened.TFrame')
+        self.instruction_frame.configure(style='Primary.TFrame')
         self.memory_frame.configure(style='Primary.TFrame')
         self.control_frame.configure(style='Primary.TFrame')
 

--- a/src/gui.py
+++ b/src/gui.py
@@ -8,15 +8,14 @@ from tkinter import filedialog, messagebox, ttk, font, colorchooser
 import json
 import os
 
-        
 class ColoredText(tk.Text):
     '''Class to handle colored text from termcolor in the GUI'''
     def __init__(self, *args, **kwargs):
         '''Initialize the ColoredText class to inherit from the Text tkinter class'''
         super().__init__(*args, **kwargs)
-        self.tag_configure("secondary", foreground="#e0e0e0")  # Default secondary color
-        self.tag_configure("primary", foreground="#000000")    # Default primary color
-        self.tag_configure("center", justify="center")  # Left justification configuration
+        self.tag_configure("primary", foreground=COLOR["primary_text"])
+        self.tag_configure("secondary", foreground=COLOR["secondary_text"])
+        self.tag_configure("center", justify="center") 
 
     def insert_colored_text(self, text, color=None):
         '''Insert colored text into the text widget'''
@@ -232,6 +231,14 @@ class ColorChooser:
         self.primary_text_label.config(text=self.primary_text_color)
         self.secondary_text_label.config(text=self.secondary_text_color)
 
+# Default color scheme
+COLOR = {
+            "primary" : "#4C721D",
+            "secondary" : "#FFFFFF",
+            "primary_text" : "#000000",
+            "secondary_text" : "#505050",
+            "darkened_color" : "#d0d0d0"
+        }
 
 class App:
     '''GUI functionality'''
@@ -242,11 +249,11 @@ class App:
         self.cpu = boot.cpu
 
         # Initialize default colors
-        self.default_primary_color = "#f0f0f0"  # Light gray for backgrounds
-        self.default_secondary_color = "#e0e0e0"  # Slightly darker gray for buttons/accents
-        self.default_primary_text_color = "#000000"  # Black for main text
-        self.default_secondary_text_color = "#505050"  # Dark gray for secondary text
-        self.default_darkened_color = "#d0d0d0"  # Darker gray for inactive frames
+        self.default_primary_color = COLOR["primary"]  # Dark green for backgrounds
+        self.default_secondary_color = COLOR["secondary"]  # Slightly darker gray for buttons/accents
+        self.default_primary_text_color = COLOR["primary_text"]  # Black for main text
+        self.default_secondary_text_color = COLOR["secondary_text"]  # Dark gray for secondary text
+        self.default_darkened_color = COLOR["darkened_color"]  # Darker gray for inactive frames
 
         # Set current colors to default
         self.primary_color = self.default_primary_color
@@ -295,10 +302,10 @@ class App:
         '''Sets up the menu bar and its behavior'''
         menubar = Menu(self.root)
         filemenu = Menu(menubar, tearoff=0)
-        filemenu.add_command(label="Open", command=self.load_file)  # Add open file option
-        filemenu.add_command(label="Clear", command=self.clear_program)  # Add clear program option
-        filemenu.add_command(label="Exit", command=self.root.quit)  # Add exit option
-        menubar.add_cascade(label="File", menu=filemenu)  # Add file menu to menubar
+        filemenu.add_command(label="Open", command=self.load_file)
+        filemenu.add_command(label="Clear", command=self.clear_program)
+        filemenu.add_command(label="Exit", command=self.root.quit)
+        menubar.add_cascade(label="File", menu=filemenu)
 
         appearancemenu = Menu(menubar, tearoff=0)
         appearancemenu.add_command(label="Customize Colors", command=self.open_color_dialog)
@@ -322,38 +329,30 @@ class App:
         prog_input_frame.grid(row=0, column=0, sticky="ns") # Sticks to the top left
 
         # Configure prog_input_frame grid weights
-        prog_input_frame.grid_rowconfigure(4, weight=1)  # Make row with program_text expandable
+        prog_input_frame.grid_rowconfigure(2, weight=1)  # Make row with program_text expandable
         prog_input_frame.grid_columnconfigure((0, 1), weight=0)  # Make columns equal width
 
         # Declare and Place Program Input Frame, Scrollbar, buttons, and opcode textbox
         load_file_btn = ttk.Button(prog_input_frame, text="Load File", command=self.load_file, padding=5)
         clear_btn = ttk.Button(prog_input_frame, text="Clear", command=self.clear_program, padding=5)
-        
         load_mem_btn = ttk.Button(prog_input_frame, text="Load Into Memory", command=self.load_memory, padding=5)
-        save_prog_btn = ttk.Button(prog_input_frame, text="Save Program", command=self.save_file, padding=5)
-        self.program_text = tk.Text(prog_input_frame, height=25, width=10)
+        self.program_text = tk.Text(prog_input_frame, width=10)
         scrollbar = ttk.Scrollbar(prog_input_frame, orient=VERTICAL, command=self.program_text.yview)
-        self.program_text.config(font=("Consolas", 25), yscrollcommand=scrollbar.set)  # Increase text font size and add scrollbar
+        # Add a small separator
+        separator = ttk.Separator(prog_input_frame, orient=HORIZONTAL)
+        save_prog_btn = ttk.Button(prog_input_frame, text="Save Program", command=self.save_file, padding=5)
 
         load_file_btn.grid(column=0, row=0, padx=3, pady=3, sticky="ew")
         clear_btn.grid(column=1, row=0, padx=3, pady=3, sticky="ew")
-
-        load_mem_btn.grid(column=0, row=2, columnspan=2, padx=3, pady=3, sticky="ew")
-
-        
-        # Add a small separator
-        separator = ttk.Separator(prog_input_frame, orient=HORIZONTAL)
+        load_mem_btn.grid(column=0, row=1, columnspan=2, padx=3, pady=3, sticky="ew")
+        self.program_text.grid(column=0, row=2, columnspan=2, padx=5, pady=5, sticky="new")
+        scrollbar.grid(column=1, row=2, pady=5, sticky="nse")
         separator.grid(column=0, row=3, columnspan=2, padx=3, pady=5, sticky="ew")
-        
-        self.program_text.grid(column=0, row=4, columnspan=2, padx=5, pady=5, sticky="nsew")
-        scrollbar.grid(column=2, row=4, pady=5, sticky="ns")
+        save_prog_btn.grid(column=0, row=4, columnspan=2, padx=5, pady=5, sticky="ew")
+
+        self.program_text.config(font=("Consolas", 25), yscrollcommand=scrollbar.set)  # Increase text font size and add scrollbar
 
         return prog_input_frame
-      
-#         self.program_text.grid(column=0, row=3, columnspan=2, padx=5, pady=5, sticky="nsew")
-#         save_prog_btn.grid(column=0, row=4, columnspan=2, padx=5, pady=5, sticky="ew")
-#         scrollbar.grid(column=2, row=3, pady=5, sticky="ns")
-
 
     def setup_main_frame(self):
         '''Sets up the main frame of the program. Including the instruction frame, memory frame, and control frame.
@@ -388,7 +387,7 @@ class App:
         # Use regular tk.Label for direct color control
         self.instructions = tk.Label(inst_frame, text="Instruction", 
                                    font=("Consolas", 11), anchor="center",
-                                   bg=self.secondary_color, fg=self.primary_text_color)
+                                   bg=self.secondary_color, fg=self.primary_text_color, wraplength=700)
         inst_frame.grid(row=0, column=0, sticky="new")  # Stick to top
         self.instructions.grid(row=0, column=0, sticky="ew", ipady=24)  # Center the label
 
@@ -413,7 +412,7 @@ class App:
         memory_frame.grid_columnconfigure(0, weight=1)  # Allow the memory to expand
 
         # Place CPU info labels at the top of the memory_frame using regular labels
-        self.memory_label = tk.Label(memory_frame, text="Memory", bg=self.secondary_color, fg=self.secondary_text_color, font=("Consolas", 11))
+        self.memory_label = tk.Label(memory_frame, text="Memory", bg=self.primary_color, fg=self.secondary_text_color, font=("Consolas", 15, "bold"))
         boldseperator = ttk.Separator(memory_frame, orient=VERTICAL)
         self.pc_frame = tk.Label(memory_frame, text="PC:", bg=self.secondary_color, fg=self.secondary_text_color)
         self.pc_label = tk.Label(memory_frame, text="00", bg=self.secondary_color, fg=self.secondary_text_color)
@@ -522,28 +521,30 @@ class App:
 
     def load_memory(self):
         '''Load the program_text widget contents into memory'''
-        text = self.program_text.get("1.0", tk.END).splitlines()
-        self.mem.clear()
-        for addr, instruction in enumerate(text):
-            if instruction.strip() == "":
-                addr -= 1
-                continue
-            elif instruction.strip().__len__() > 5:
-                self.mem.write(addr, instruction[0:5])
-                continue
+        # Execute if program_text widget is not empty
+        if (self.program_text.get("1.0", tk.END).strip()):
+            text = self.program_text.get("1.0", tk.END).splitlines()
+            self.mem.clear()
+            for addr, instruction in enumerate(text):
+                if instruction.strip() == "":
+                    addr -= 1
+                    continue
+                elif instruction.strip().__len__() > 5:
+                    self.mem.write(addr, instruction[0:5])
+                    continue
 
-            try:
-                self.mem.write(addr, instruction.strip())
-            except IndexError:
-                messagebox.showerror("Error", f"Invalid address: {addr}")
-                return
-            except ValueError:
-                messagebox.showerror("Error", f"Invalid instruction: {instruction}")
-                return
-        self.status_label.config(text="Status: Ready")
-        self.update_memory_text()
-        # Switch focus to memory frame after loading
-        self.highlight_main_frame()
+                try:
+                    self.mem.write(addr, instruction.strip())
+                except IndexError:
+                    messagebox.showerror("Error", f"Invalid address: {addr}")
+                    return
+                except ValueError:
+                    messagebox.showerror("Error", f"Invalid instruction: {instruction}")
+                    return
+            self.status_label.config(text="Status: Ready")
+            self.update_memory_text()
+            # Switch focus to memory frame after loading
+            self.highlight_main_frame()
 
     def adjust_memory_font_size(self, event=None):
         '''Dynamically adjusts font size to fit text within memory_text widget with some padding.'''
@@ -633,7 +634,7 @@ class App:
             cont = False
 
         self.status_label.config(text="Status: Running")
-        # Switch focus to control frame when running
+        # Switch focus to main frame when running
         self.highlight_main_frame()
             
         try:
@@ -752,7 +753,7 @@ class App:
         
         # Define disabled entry style
         self.style.map('IO.TEntry',
-                      fieldbackground=[('disabled', self.primary_color)],
+                      fieldbackground=[('disabled', self.secondary_color)],
                       foreground=[('disabled', self.primary_text_color)],
                       background=[('disabled', self.primary_color)])
 
@@ -774,7 +775,7 @@ class App:
         
         # Update disabled state colors
         self.style.map('IO.TEntry',
-                      fieldbackground=[('disabled', self.primary_color)],
+                      fieldbackground=[('disabled', self.secondary_color)],
                       foreground=[('disabled', self.primary_text_color)],
                       background=[('disabled', self.primary_color)])
         
@@ -784,7 +785,7 @@ class App:
         # Regular Text widgets (not ttk)
         self.program_text.configure(
             bg=self.secondary_color,
-            fg=self.primary_text_color
+            fg=self.primary_text_color,
         )
         
         self.memory_text.configure(
@@ -832,6 +833,12 @@ class App:
         self.memory_frame.configure(style='Darkened.TFrame')
         self.control_frame.configure(style='Darkened.TFrame')
 
+        # Disable control frame buttons, enable program frame buttons and program_text
+        for frame, state in [(self.program_frame, tk.NORMAL), (self.control_frame, tk.DISABLED)]:
+            for child in frame.winfo_children():
+                if child.winfo_class() in ('TButton', 'Text', 'scrollbar'):
+                    child.configure(state=state)
+
         self.update_memory_text()
 
     def highlight_main_frame(self):
@@ -841,9 +848,15 @@ class App:
         self.memory_frame.configure(style='Primary.TFrame')
         self.control_frame.configure(style='Primary.TFrame')
 
+        # Enable control frame buttons, disable program frame buttons and program_text
+        for frame, state in [(self.program_frame, tk.DISABLED), (self.control_frame, tk.NORMAL)]:
+            for child in frame.winfo_children():
+                if child.winfo_class() in ('TButton', 'Text', 'scrollbar'):
+                    child.configure(state=state)
+
         self.update_memory_text()
 
-    def darken_color(self, color, factor=0.3):
+    def darken_color(self, color, factor=0.4):
         '''Darken a hex color by a given factor'''
         # Remove the '#' if present
         color = color.lstrip('#')

--- a/src/gui.py
+++ b/src/gui.py
@@ -66,6 +66,7 @@ class ColorChooser:
         self.secondary_color = parent.secondary_color
         self.primary_text_color = parent.primary_text_color
         self.secondary_text_color = parent.secondary_text_color
+        self.pc_text_color = parent.pc_text_color
         
     def adjust_color_for_hover(self, color, darken=True):
         '''Adjust color brightness for hover effect'''
@@ -154,6 +155,18 @@ class ColorChooser:
         
         self.secondary_text_label = Label(main_frame, text=self.secondary_text_color)
         self.secondary_text_label.grid(row=3, column=2, sticky=W)
+
+        Label(main_frame, text="PC Text Color:", anchor=W).grid(row=4, column=0, sticky=W, pady=5)
+        self.pc_text_btn = Frame(main_frame, width=50, height=25,
+                                      relief=RAISED, borderwidth=2)
+        self.pc_text_btn.grid(row=4, column=1, padx=10)
+        self.pc_text_btn.bind('<Button-1>', lambda e: self.choose_color("pc_text"))
+        self.pc_text_btn.bind('<Enter>', lambda e: self.on_enter(e, self.pc_text_btn, self.pc_text_color))
+        self.pc_text_btn.bind('<Leave>', lambda e: self.on_leave(e, self.pc_text_btn, self.pc_text_color))
+        self.pc_text_btn.grid_propagate(False)
+        
+        self.pc_text_label = Label(main_frame, text=self.pc_text_color)
+        self.pc_text_label.grid(row=4, column=2, sticky=W)
         
         # Configure color displays
         self.update_button_colors()
@@ -186,7 +199,7 @@ class ColorChooser:
     
     def update_button_colors(self):
         '''Update all color display frames'''
-        for color_type in ['primary', 'secondary', 'primary_text', 'secondary_text']:
+        for color_type in ['primary', 'secondary', 'primary_text', 'secondary_text', 'pc_text']:
             color = getattr(self, f"{color_type}_color")
             frame = getattr(self, f"{color_type}_btn")
             frame.configure(bg=color)
@@ -209,6 +222,7 @@ class ColorChooser:
         self.parent.secondary_color = self.secondary_color
         self.parent.primary_text_color = self.primary_text_color
         self.parent.secondary_text_color = self.secondary_text_color
+        self.parent.pc_text_color = self.pc_text_color
         
         # Apply colors to UI
         self.parent.apply_colors()
@@ -221,6 +235,7 @@ class ColorChooser:
         self.secondary_color = self.parent.default_secondary_color
         self.primary_text_color = self.parent.default_primary_text_color
         self.secondary_text_color = self.parent.default_secondary_text_color
+        self.pc_text_color = self.parent.default_pc_text_color
         
         # Update color displays
         self.update_button_colors()
@@ -230,6 +245,7 @@ class ColorChooser:
         self.secondary_label.config(text=self.secondary_color)
         self.primary_text_label.config(text=self.primary_text_color)
         self.secondary_text_label.config(text=self.secondary_text_color)
+        self.pc_text_label.config(text=self.pc_text_color)
 
 # Default color scheme
 COLOR = {
@@ -237,8 +253,16 @@ COLOR = {
             "secondary" : "#FFFFFF",
             "primary_text" : "#000000",
             "secondary_text" : "#505050",
-            "darkened_color" : "#d0d0d0"
+            "darkened_color" : "#d0d0d0",
+            "pc" : "#008000"
         }
+
+# Default font scheme
+FONT = {
+            "header" : ("Consolas", 21, "bold"),
+            "primary" : ("Consolas", 18),
+            "secondary" : ("Consolas", 14),
+}
 
 class App:
     '''GUI functionality'''
@@ -250,17 +274,20 @@ class App:
 
         # Initialize default colors
         self.default_primary_color = COLOR["primary"]  # Dark green for backgrounds
-        self.default_secondary_color = COLOR["secondary"]  # Slightly darker gray for buttons/accents
+        self.default_secondary_color = COLOR["secondary"]  # White accent
         self.default_primary_text_color = COLOR["primary_text"]  # Black for main text
         self.default_secondary_text_color = COLOR["secondary_text"]  # Dark gray for secondary text
+        self.default_pc_text_color = COLOR["pc"]  # Green for PC text
         self.default_darkened_color = COLOR["darkened_color"]  # Darker gray for inactive frames
-
+        
         # Set current colors to default
         self.primary_color = self.default_primary_color
         self.secondary_color = self.default_secondary_color
         self.primary_text_color = self.default_primary_text_color
         self.secondary_text_color = self.default_secondary_text_color
+        self.pc_text_color = self.default_pc_text_color
         self.darkened_color = self.default_darkened_color
+        
 
         self.setup_root()
         
@@ -293,8 +320,8 @@ class App:
         '''Sets up the root behavior of the window'''
         self.root = tk.Tk()
         self.root.title("UVSim - BasicML Simulator")
-        self.root.geometry('960x552')
-        self.root.minsize(960, 552)
+        self.root.geometry('1007x600')
+        self.root.minsize(1007, 600)
         self.root.iconbitmap('gui/cpu.ico')
         
     
@@ -336,7 +363,7 @@ class App:
         load_file_btn = ttk.Button(prog_input_frame, text="Load File", command=self.load_file, padding=5)
         clear_btn = ttk.Button(prog_input_frame, text="Clear", command=self.clear_program, padding=5)
         load_mem_btn = ttk.Button(prog_input_frame, text="Load Into Memory", command=self.load_memory, padding=5)
-        self.program_text = tk.Text(prog_input_frame, width=10)
+        self.program_text = tk.Text(prog_input_frame, width=10, font=FONT["primary"], wrap=NONE)
         scrollbar = ttk.Scrollbar(prog_input_frame, orient=VERTICAL, command=self.program_text.yview)
         # Add a small separator
         separator = ttk.Separator(prog_input_frame, orient=HORIZONTAL)
@@ -345,12 +372,12 @@ class App:
         load_file_btn.grid(column=0, row=0, padx=3, pady=3, sticky="ew")
         clear_btn.grid(column=1, row=0, padx=3, pady=3, sticky="ew")
         load_mem_btn.grid(column=0, row=1, columnspan=2, padx=3, pady=3, sticky="ew")
-        self.program_text.grid(column=0, row=2, columnspan=2, padx=5, pady=5, sticky="new")
+        self.program_text.grid(column=0, row=2, columnspan=2, padx=5, pady=5, sticky="nsew")
         scrollbar.grid(column=1, row=2, pady=5, sticky="nse")
         separator.grid(column=0, row=3, columnspan=2, padx=3, pady=5, sticky="ew")
         save_prog_btn.grid(column=0, row=4, columnspan=2, padx=5, pady=5, sticky="ew")
 
-        self.program_text.config(font=("Consolas", 25), yscrollcommand=scrollbar.set)  # Increase text font size and add scrollbar
+        self.program_text.config(yscrollcommand=scrollbar.set)  # Decreased font size per todos, fixed scrollbar to be inside the textbox
 
         return prog_input_frame
 
@@ -386,13 +413,14 @@ class App:
 
         # Use regular tk.Label for direct color control
         self.instructions = tk.Label(inst_frame, text="Instruction", 
-                                   font=("Consolas", 11), anchor="center",
-                                   bg=self.secondary_color, fg=self.primary_text_color, wraplength=700)
+                                   font=FONT["secondary"], anchor="center",
+                                   bg=self.secondary_color, fg=self.primary_text_color, 
+                                   wraplength=700, width=100, height=2) # Ensure instruction window doesn't resize when it is updated
         inst_frame.grid(row=0, column=0, sticky="new")  # Stick to top
-        self.instructions.grid(row=0, column=0, sticky="ew", ipady=24)  # Center the label
+        self.instructions.grid(row=0, column=0, sticky="ew", ipady=25)  # Center the label
 
         seperator = ttk.Separator(inst_frame, orient=HORIZONTAL)
-        seperator.grid(row=1, column=0, columnspan=3, sticky="ew") # Add a separator
+        seperator.grid(row=1, column=0, sticky="ew", pady=(10, 0)) # Add a separator, ensure padding is set for top only to seperate it from the label
 
         return inst_frame
 
@@ -412,29 +440,29 @@ class App:
         memory_frame.grid_columnconfigure(0, weight=1)  # Allow the memory to expand
 
         # Place CPU info labels at the top of the memory_frame using regular labels
-        self.memory_label = tk.Label(memory_frame, text="Memory", bg=self.primary_color, fg=self.secondary_text_color, font=("Consolas", 15, "bold"))
+        self.memory_label = tk.Label(memory_frame, text="Memory", bg=self.primary_color, fg=self.primary_text_color, font=FONT["header"], padx=5)
         boldseperator = ttk.Separator(memory_frame, orient=VERTICAL)
-        self.pc_frame = tk.Label(memory_frame, text="PC:", bg=self.secondary_color, fg=self.secondary_text_color)
-        self.pc_label = tk.Label(memory_frame, text="00", bg=self.secondary_color, fg=self.secondary_text_color)
+        self.pc_frame = tk.Label(memory_frame, text="PC:", bg=self.secondary_color, fg=self.secondary_text_color, font=FONT["secondary"])
+        self.pc_label = tk.Label(memory_frame, text="00", bg=self.secondary_color, fg=self.secondary_text_color, font=FONT["secondary"])
         seperator1 = ttk.Separator(memory_frame, orient=VERTICAL)
-        self.acc_frame = tk.Label(memory_frame, text="Accumulator:", bg=self.secondary_color, fg=self.secondary_text_color)
-        self.acc_label = tk.Label(memory_frame, text="+0000", bg=self.secondary_color, fg=self.secondary_text_color)
+        self.acc_frame = tk.Label(memory_frame, text="Accumulator:", bg=self.secondary_color, fg=self.secondary_text_color, font=FONT["secondary"])
+        self.acc_label = tk.Label(memory_frame, text="+0000", bg=self.secondary_color, fg=self.secondary_text_color, font=FONT["secondary"])
         seperator2 = ttk.Separator(memory_frame, orient=VERTICAL)
-        self.status_label = tk.Label(memory_frame, text="Status: Ready", bg=self.secondary_color, fg=self.secondary_text_color, relief=tk.SUNKEN, anchor=tk.W)
+        self.status_label = tk.Label(memory_frame, text="Status: Ready", bg=self.secondary_color, fg=self.secondary_text_color, relief=tk.SUNKEN, anchor=tk.W, font=FONT["secondary"])
         boldseperator1 = ttk.Separator(memory_frame, orient=HORIZONTAL)
-        self.memory_text = ColoredText(memory_frame, height=11, width=64, font=("Courier", 12), wrap=NONE, state=tk.DISABLED)
+        self.memory_text = ColoredText(memory_frame, height=11, width=64, font=FONT["secondary"], wrap=NONE, state=tk.DISABLED)
         self.memory_text.tag_configure("center", justify="center")
         
-        # Place Memory Frame and its components
+        # Place Memory Frame and its components, ensuring they expand to fill the space
         self.memory_label.grid(row=0, column=0, sticky=W)
-        boldseperator.grid(row=0, column=1, sticky=NS)
-        self.pc_frame.grid(row=0, column=2)
-        self.pc_label.grid(row=0, column=3)
+        boldseperator.grid(row=0, column=1, sticky=S)
+        self.pc_frame.grid(row=0, column=2, sticky=NS)
+        self.pc_label.grid(row=0, column=3, sticky=NS)
         seperator1.grid(row=0, column=4, sticky=NS)
-        self.acc_frame.grid(row=0, column=5)
-        self.acc_label.grid(row=0, column=6)
+        self.acc_frame.grid(row=0, column=5, sticky=NS)
+        self.acc_label.grid(row=0, column=6, sticky=NS)
         seperator2.grid(row=0, column=7, sticky=NS)
-        self.status_label.grid(row=0, column=8, sticky=EW)
+        self.status_label.grid(row=0, column=8, sticky=NSEW)
         boldseperator1.grid(row=1, column=0, columnspan=9, sticky=EW)
 
         # Update memory text to expand
@@ -465,9 +493,9 @@ class App:
         halt_btn = ttk.Button(control_frame, text="Halt", command=self.halt_program, padding=5)
         reset_btn = ttk.Button(control_frame, text="Reset", command=self.reset_program, padding=5)
         seperator3 = ttk.Separator(control_frame, orient=VERTICAL)
-        self.io_label = tk.Label(control_frame, text="I/O", font=("Consolas", 11), 
-                              bg=self.secondary_color, fg=self.secondary_text_color)
-        self.io_text = ttk.Entry(control_frame, font=("Consolas", 25), state=tk.DISABLED, style='IO.TEntry')
+        self.io_label = tk.Label(control_frame, text="I/O", font=FONT["secondary"],
+                              bg=self.secondary_color, fg=self.secondary_text_color, padx=5)
+        self.io_text = ttk.Entry(control_frame, font=FONT["primary"], state=tk.DISABLED, style='IO.TEntry')
 
         control_frame.grid(row=2, column=0, sticky="sew")  # Stick to bottom
 
@@ -476,9 +504,8 @@ class App:
         halt_btn.grid(row=2, rowspan=2, column=0, padx=5, pady=5, sticky="w")
         reset_btn.grid(row=2, rowspan=2, column=1, padx=5, pady=5, sticky="w")
         seperator3.grid(row=0, rowspan=4, column=2, sticky="nsw")
-        self.io_label.grid(row=0, column=2, padx=5, pady=5, sticky="nw")
-        self.io_text.grid(row=1, rowspan=3, column=2, padx=5, pady=5, sticky="ew")
-
+        self.io_label.grid(row=0, column=2, padx=5, pady=(5, 0), sticky="nsw")
+        self.io_text.grid(row=1, rowspan=3, column=2, padx=5, pady=5, sticky="sew")
 
         return control_frame
 
@@ -586,7 +613,7 @@ class App:
         self.memory_text.delete("1.0", tk.END)
 
         # Update the colors for the memory text widget
-        self.memory_text.set_colors(self.primary_text_color, self.secondary_text_color)
+        self.memory_text.set_colors(self.primary_text_color, self.pc_text_color)
 
         # Get the current memory lines as a list
         if not text:
@@ -615,8 +642,8 @@ class App:
             
         self.memory_text.tag_add("center", "1.0", "end")
         self.memory_text.config(state=tk.DISABLED)
-        self.pc_label.config(text=str(self.cpu.pointer))
-        self.acc_label.config(text=str(self.cpu.accumulator))
+        self.pc_label.config(text=f"{self.cpu.pointer:02d}") # Ensure PC is always 2 digits
+        self.acc_label.config(text=f"{"+" if self.cpu.accumulator >= 0 else "-"}{abs(int(self.cpu.accumulator)):04d}") # Ensure accumulator is always at least 5 digits
         self.adjust_memory_font_size()
 
     def run_program(self):
@@ -657,8 +684,6 @@ class App:
             self.cpu.halted = False
 
         self.status_label.config(text="Status: Stepped")
-        self.pc_label.config(text=str(self.cpu.pointer))
-        self.acc_label.config(text=str(self.cpu.accumulator))
 
         try:
             operand = self.mem.word_to_int(self.mem.read(self.cpu.pointer))
@@ -833,12 +858,6 @@ class App:
         self.memory_frame.configure(style='Darkened.TFrame')
         self.control_frame.configure(style='Darkened.TFrame')
 
-        # Disable control frame buttons, enable program frame buttons and program_text
-        for frame, state in [(self.program_frame, tk.NORMAL), (self.control_frame, tk.DISABLED)]:
-            for child in frame.winfo_children():
-                if child.winfo_class() in ('TButton', 'Text', 'scrollbar'):
-                    child.configure(state=state)
-
         self.update_memory_text()
 
     def highlight_main_frame(self):
@@ -847,12 +866,6 @@ class App:
         self.instruction_frame.configure(style='Primary.TFrame')
         self.memory_frame.configure(style='Primary.TFrame')
         self.control_frame.configure(style='Primary.TFrame')
-
-        # Enable control frame buttons, disable program frame buttons and program_text
-        for frame, state in [(self.program_frame, tk.DISABLED), (self.control_frame, tk.NORMAL)]:
-            for child in frame.winfo_children():
-                if child.winfo_class() in ('TButton', 'Text', 'scrollbar'):
-                    child.configure(state=state)
 
         self.update_memory_text()
 
@@ -869,6 +882,3 @@ class App:
         
         # Convert back to hex
         return '#{:02x}{:02x}{:02x}'.format(*darkened_rgb)
-
-
-


### PR DESCRIPTION
If yall hate the color scheme just lmk, I wasn't sure how I could incorporate the green super well so I went for the background instead of green text. I also replaced the save program button on the program_frame grid, I think this was accidentally commented out. I did some reconfiguring to the program_frame grid to make things fit better and put the scrollbar inside the program_text textbox. Adjusted all font sizes and created the FONT dictionary. 

Updated the PC and accumulator labels to have the right minimum amount of digits.

I also edited OP_Read function in cpu.py to ensure the user is told to hit enter when submitting a read operation. I resized the minimum window size after this to make the sure text fits and is a standard size still from the dictionary.